### PR TITLE
Fix binance csv data reading

### DIFF
--- a/coinview/backtest.py
+++ b/coinview/backtest.py
@@ -19,7 +19,7 @@ cerebro = bt.Cerebro()
 fromdate = datetime.datetime.strptime('2020-07-01', '%Y-%m-%d')
 todate = datetime.datetime.strptime('2020-07-12', '%Y-%m-%d')
 
-data = bt.feeds.GenericCSVData(dataname='data/2020_15minutes.csv', dtformat=2, compression=15, timeframe=bt.TimeFrame.Minutes, fromdate=fromdate, todate=todate)
+data = bt.feeds.GenericCSVData(dataname='data/2020_15minutes.csv', dtformat=2, compression=15, timeframe=bt.TimeFrame.Minutes, fromdate=fromdate, todate=todate, headers=False)
 
 cerebro.adddata(data)
 


### PR DESCRIPTION
When using `bt.feeds.GenericCSVData` to read csv from binance we need to set `headers` to `False` so 1st row doesn't get overwritten. 

If you check the data that is loaded by `GenericCSVData` you will notice that 1st row from binance csv is always missing.

If you downloaded 15 min candlesticks your strategy will not have 1st candlestick, it will start from second one. E.g. if your first candlestick should be at 22:00 and second one at 22:15, your strategy will take 22:15 as the first one. You can reproduce this either by looking at the chart when you plot or stick in `ipdb` into `__init__` of your strategy and check `self.data.SOME_LINE[0]` and you will see that it is not matching to the 1st line in the csv. Instead of `SOME_LINE` you can put in datetime,high,close,open,close and other values that are mentioned in backtrader docs.